### PR TITLE
add support for indefinite leases on port mapping

### DIFF
--- a/lib/nat-upnp/device.js
+++ b/lib/nat-upnp/device.js
@@ -125,7 +125,7 @@ Device.prototype.run = function run(action, args, callback) {
                           JSON.stringify(info.service) + '>' +
                     args.map(function(args) {
                       return '<' + args[0]+ '>' +
-                             (typeof args[1] === 'undefined' ? '' : args[1]) +
+                             (args[1] === undefined ? '' : args[1]) +
                              '</' + args[0] + '>';
                     }).join('') +
                   '</u:' + action + '>' +


### PR DESCRIPTION
Some routers - namely mine - do not support temporary leases. So, after a bit of research into UPNP, I discovered that you can request an indefinite lease by supplying the value `ui4` as the `NewLeaseDuration` parameter - which I have no idea why or what that value even means.

So, now if you supply `Infinity` as the `ttl` value on `portMapping()`, you will request an indefinite lease.
