### PR TITLE
use correct client address as NewInternalClient in portMapping

### DIFF
--- a/lib/nat-upnp/client.js
+++ b/lib/nat-upnp/client.js
@@ -29,7 +29,7 @@ function normalizeOptions(options) {
 Client.prototype.portMapping = function portMapping(options, callback) {
   if (!callback) callback = function() {};
 
-  this.findGateway(function(err, gateway, address) {
+  this.findGateway(function(err, gateway, gwAddress, clientAddress) {
     if (err) return callback(err);
 
     var ports = normalizeOptions(options);
@@ -40,7 +40,7 @@ Client.prototype.portMapping = function portMapping(options, callback) {
       [ 'NewProtocol', options.protocol ?
           options.protocol.toUpperCase() : 'TCP' ],
       [ 'NewInternalPort', ports.internal.port ],
-      [ 'NewInternalClient', ports.internal.host || address ],
+      [ 'NewInternalClient', ports.internal.host || clientAddress ],
       [ 'NewEnabled', 1 ],
       [ 'NewPortMappingDescription', options.description || 'node:nat:upnp' ],
       [ 'NewLeaseDuration', typeof options.ttl === 'number' ?

--- a/lib/nat-upnp/ssdp.js
+++ b/lib/nat-upnp/ssdp.js
@@ -151,7 +151,7 @@ Ssdp.prototype.parseResponse = function parseResponse(response, addr, remote) {
   // search target
   if (!headers.st) return;
 
-  this.emit('_device', headers, remote.address);
+  this.emit('_device', headers, addr);
 };
 
 Ssdp.prototype.close = function close() {

--- a/lib/nat-upnp/ssdp.js
+++ b/lib/nat-upnp/ssdp.js
@@ -80,11 +80,11 @@ Ssdp.prototype.search = function search(device, promise) {
     socket.send(query, 0, query.length, this.port, this.multicast);
   }, this);
 
-  function ondevice(info, address) {
+  function ondevice(info, gwAddress, clientAddress) {
     if (promise._ended) return;
     if (info.st !== device) return;
 
-    promise.emit('device', info, address);
+    promise.emit('device', info, gwAddress, clientAddress);
   }
   this.on('_device', ondevice);
 
@@ -151,7 +151,7 @@ Ssdp.prototype.parseResponse = function parseResponse(response, addr, remote) {
   // search target
   if (!headers.st) return;
 
-  this.emit('_device', headers, addr);
+  this.emit('_device', headers, remote, addr);
 };
 
 Ssdp.prototype.close = function close() {


### PR DESCRIPTION
Currently if no internal host property is provided when doing a port mapping request, the gateway ip address is being used as the NewInternalClient parameter. This  results in an error response from the gateway.

This update adds an argument to the on 'device' event callback, the value of the local address of he client which found the gateway, to be used correctly as the NewInternalClient parameter.