### PR TITLE
client: add support for 0-based indexed routers in getMappings

### DIFF
--- a/lib/nat-upnp/client.js
+++ b/lib/nat-upnp/client.js
@@ -87,10 +87,13 @@ Client.prototype.getMappings = function getMappings(options, callback) {
       return !end;
     }, function(callback) {
       gateway.run('GetGenericPortMappingEntry', [
-        [ 'NewPortMappingIndex', ++i ]
+        [ 'NewPortMappingIndex', i++ ]
       ], function(err, data) {
         if (err) {
-          end = true;
+          // If we got an error on index 0, ignore it in case this router starts indicies on 1
+          if (i !== 1) {
+            end = true;
+          }
           return callback(null);
         }
 


### PR DESCRIPTION
This change makes getMappings start at 0 to support 0-based indexed routers.  However, it will still check index 1 if index 0 fails to hopefully still support 1-based indexed routers. Addresses issue #28.