### PR TITLE
Fix bug that is enabled property is always false

### DIFF
--- a/lib/nat-upnp/client.js
+++ b/lib/nat-upnp/client.js
@@ -117,7 +117,7 @@ Client.prototype.getMappings = function getMappings(options, callback) {
             port: parseInt(data.NewInternalPort, 10)
           },
           protocol: data.NewProtocol.toLowerCase(),
-          enabled: data.NewEnabled === 1,
+          enabled: data.NewEnabled === '1',
           description: data.NewPortMappingDescription,
           ttl: parseInt(data.NewLeaseDuration, 10)
         };


### PR DESCRIPTION
`enabled` property of result of getMappings is always false. 
because, `data.NewEnabled` is string tpye.
Therefore, when you use the `===` operator, you need to compare it with the string type, not the number.

